### PR TITLE
Add Kafka consumer and publisher services for driver location updates

### DIFF
--- a/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/config/JacksonConfig.java
+++ b/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.codingdecoded.sunchit.kafka.consumer.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+} 

--- a/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/config/KafkaTopicConfig.java
+++ b/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/config/KafkaTopicConfig.java
@@ -1,0 +1,25 @@
+package com.codingdecoded.sunchit.kafka.consumer.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value("${kafka.topic.driver-location}")
+    private String topicName;
+    
+    @Value("${kafka.topic.partitions}")
+    private int partitions;
+
+    @Bean
+    public NewTopic driverLocationTopic() {
+        return TopicBuilder.name(topicName)
+                .partitions(partitions)
+                .replicas(1)
+                .build();
+    }
+} 

--- a/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/config/KafkaTopicConfig.java
+++ b/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/config/KafkaTopicConfig.java
@@ -15,11 +15,14 @@ public class KafkaTopicConfig {
     @Value("${kafka.topic.partitions}")
     private int partitions;
 
+    @Value("${kafka.topic.replicas}")
+    private int replicas;
+
     @Bean
     public NewTopic driverLocationTopic() {
         return TopicBuilder.name(topicName)
                 .partitions(partitions)
-                .replicas(1)
+                .replicas(replicas)
                 .build();
     }
 } 

--- a/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/AnalyticsConsumerService.java
+++ b/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/AnalyticsConsumerService.java
@@ -3,13 +3,15 @@ package com.codingdecoded.sunchit.kafka.consumer.consumer;
 import com.codingdecoded.sunchit.kafka.consumer.model.DriverLocation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AnalyticsConsumerService {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @KafkaListener(topics = "${kafka.topic.driver-location}", groupId = "${analytics.consumer.group-id}")
     public void consume(ConsumerRecord<String, String> record) {

--- a/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/AnalyticsConsumerService.java
+++ b/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/AnalyticsConsumerService.java
@@ -1,0 +1,36 @@
+package com.codingdecoded.sunchit.kafka.consumer.consumer;
+
+import com.codingdecoded.sunchit.kafka.consumer.model.DriverLocation;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AnalyticsConsumerService {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @KafkaListener(topics = "${kafka.topic.driver-location}", groupId = "${analytics.consumer.group-id}")
+    public void consume(ConsumerRecord<String, String> record) {
+        try {
+            String key = record.key();
+            String value = record.value();
+
+            DriverLocation location = objectMapper.readValue(value, DriverLocation.class);
+
+            System.out.println("📊 Analytics consumer received location update for driver " + location.getDriverId());
+            System.out.println("   Coordinates: " + location.getLatitude() + ", " + location.getLongitude());
+            System.out.println("   Time: " + location.getTimestamp());
+
+            processForAnalytics(location);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void processForAnalytics(DriverLocation location) {
+        System.out.println("📈 Processing driver location for analytics: " + location.getDriverId());
+    }
+} 

--- a/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/NotificationConsumerService.java
+++ b/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/NotificationConsumerService.java
@@ -3,13 +3,15 @@ package com.codingdecoded.sunchit.kafka.consumer.consumer;
 import com.codingdecoded.sunchit.kafka.consumer.model.DriverLocation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Service
 public class NotificationConsumerService {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @KafkaListener(topics = "${kafka.topic.driver-location}", groupId = "${notification.consumer.group-id}")
     public void consume(ConsumerRecord<String, String> record) {

--- a/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/NotificationConsumerService.java
+++ b/kafka-consumer/src/main/java/com/codingdecoded/sunchit/kafka/consumer/consumer/NotificationConsumerService.java
@@ -1,0 +1,36 @@
+package com.codingdecoded.sunchit.kafka.consumer.consumer;
+
+import com.codingdecoded.sunchit.kafka.consumer.model.DriverLocation;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationConsumerService {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @KafkaListener(topics = "${kafka.topic.driver-location}", groupId = "${notification.consumer.group-id}")
+    public void consume(ConsumerRecord<String, String> record) {
+        try {
+            String key = record.key();
+            String value = record.value();
+
+            DriverLocation location = objectMapper.readValue(value, DriverLocation.class);
+
+            System.out.println("🔔 Notification consumer received location update for driver " + location.getDriverId());
+            System.out.println("   Coordinates: " + location.getLatitude() + ", " + location.getLongitude());
+            System.out.println("   Time: " + location.getTimestamp());
+
+            sendNotifications(location);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void sendNotifications(DriverLocation location) {
+        System.out.println("📱 Sending push notifications for driver: " + location.getDriverId());
+    }
+} 

--- a/kafka-consumer/src/main/resources/application.properties
+++ b/kafka-consumer/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 kafka.bootstrap-servers=localhost:9092
 kafka.topic.driver-location=driver-location-updates
 kafka.topic.partitions=3
+kafka.topic.replicas=3
 
 # Spring Kafka Consumer config
 spring.kafka.consumer.bootstrap-servers=${kafka.bootstrap-servers}

--- a/kafka-consumer/src/main/resources/application.properties
+++ b/kafka-consumer/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 # Kafka basic settings
 kafka.bootstrap-servers=localhost:9092
 kafka.topic.driver-location=driver-location-updates
+kafka.topic.partitions=3
 
 # Spring Kafka Consumer config
 spring.kafka.consumer.bootstrap-servers=${kafka.bootstrap-servers}
@@ -9,5 +10,9 @@ spring.kafka.consumer.group-id=rider-location-consumer
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.auto-offset-reset=earliest
+
+# Additional consumer groups
+analytics.consumer.group-id=analytics-consumer-group
+notification.consumer.group-id=notification-consumer-group
 
 server.port=8081

--- a/kafka-publisher/src/main/java/com/codingdecoded/sunchit/kafka/publisher/config/KafkaTopicConfig.java
+++ b/kafka-publisher/src/main/java/com/codingdecoded/sunchit/kafka/publisher/config/KafkaTopicConfig.java
@@ -1,0 +1,25 @@
+package com.codingdecoded.sunchit.kafka.publisher.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value("${kafka.topic.driver-location}")
+    private String topicName;
+    
+    @Value("${kafka.topic.partitions}")
+    private int partitions;
+
+    @Bean
+    public NewTopic driverLocationTopic() {
+        return TopicBuilder.name(topicName)
+                .partitions(partitions)
+                .replicas(1)
+                .build();
+    }
+} 

--- a/kafka-publisher/src/main/resources/application.properties
+++ b/kafka-publisher/src/main/resources/application.properties
@@ -10,6 +10,7 @@ kafka.bootstrap-servers=localhost:9092
 
 # Topic for driver location updates
 kafka.topic.driver-location=driver-location-updates
+kafka.topic.partitions=4
 
 
 # (Optional) Additional Kafka settings


### PR DESCRIPTION
- Implemented `AnalyticsConsumerService` and `NotificationConsumerService` to handle driver location updates.
- Created `KafkaTopicConfig` for topic configuration in both consumer and publisher modules.
- Updated `application.properties` to include topic partition settings and consumer group IDs.
- Ensured proper deserialization of `DriverLocation` objects from Kafka messages.